### PR TITLE
Fix parsing of while-loops

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -276,9 +276,9 @@ function ConditionBlock(entry, buffer, os) {
     let ros = os - 1;
     while ((ch = buffer[ros]) && ~_nb_white.indexOf(ch)) ros--;
 
-    // if there is and it's not a ';' then it's not a block at all,
+    // if there is and it's not a newline or ';' then it's not a block at all,
     // just set the exit at the end of the line
-    if (~_eol.indexOf(ch)) {
+    if (!~_eol.indexOf(ch)) {
         os += entry.length;
         while ((ch = buffer[os]) && !~_eol.indexOf(ch) && ch !== '#') os++;
         return {

--- a/test/parse.js
+++ b/test/parse.js
@@ -151,7 +151,7 @@ def other!
 end`;
             check(contextString);
         });
-        it("recognises a while", function() {
+        it("recognises two whiles", function() {
             const contextString = `
 def fn
   a = 1 while false
@@ -159,6 +159,29 @@ def fn
     b = 1
     break
   end
+end
+
+def other!
+end`;
+            check(contextString);
+        });
+        it("recognises a single while", function() {
+          const contextString = `
+def fn
+ while true
+    a = 1
+    break
+  end
+end
+
+def other!
+end`;
+            check(contextString);
+        });
+        it("recognises a while modifier", function() {
+          const contextString = `
+def fn
+ a = 1 while false
 end
 
 def other!


### PR DESCRIPTION
This PR fixes a bug in the handling of `while`/`until` blocks. I.e. the code used an inverted if-condition leading to while-blocks being handle like while-modifiers and vice versa. Therefore, in code like this:

```ruby
def fn
 while true
    a = 1
    break
  end
end

def other!
end;
```

the `while` was handled as if it was a modifier and therefore the corresponding `end` leads to an early out of the parsing process and no methods after that will be picked up.

The existing test case didn't fail because it contained both, the modifier- and block-version of the `while` loop.
